### PR TITLE
Remove external/srec

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -209,7 +209,6 @@
   <project path="external/sfntly" name="platform/external/sfntly" groups="pdk-cw-fs,qcom_msm8x26" remote="aosp" />
   <project path="external/smack" name="platform/external/smack" groups="pdk-cw-fw" remote="aosp" />
   <project path="external/smali" name="platform/external/smali" groups="pdk-cw-fs" remote="aosp" />
-  <project path="external/srec" name="platform/external/srec" groups="pdk-cw-fs" remote="aosp" />
   <project path="external/srtp" name="platform/external/srtp" groups="pdk-cw-fs" remote="aosp" />
   <project path="external/stlport" name="platform/external/stlport" groups="pdk" remote="aosp" />
   <project path="external/stressapptest" name="platform/external/stressapptest" groups="pdk-cw-fs" remote="aosp" />


### PR DESCRIPTION
* This is not used for anything anymore
* AOSP master has removed it together with VoiceDialer
  which we already killed

Change-Id: Ib7316d87b98b6f3c761ec9a042ed8b1a1aa9c047